### PR TITLE
correct version of package-lock to fix travis testing issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.tinker",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
please ensure to run in you dev-environment npm I after merge, the whole package lock must be updated but I can't do that on my Mac setup as it needs a different OS.

when version is fixed and npm I updated the package lock all test should run and we can merge it into stable